### PR TITLE
Add cert-manager namespace

### DIFF
--- a/modules/aws/cert-manager/main.tf
+++ b/modules/aws/cert-manager/main.tf
@@ -58,6 +58,12 @@ resource "kubernetes_config_map" "config" {
   }
 }
 
+resource "kubernetes_namespace" "cert-manager" {
+  metadata {
+    name = "cert-manager"
+  }
+}
+
 module "cert_manager_irsa" {
   source                        = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
   version                       = "5.43.0"


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [x] Bug Fix

## Linked tickets

[BRID-58](https://digicatapult.atlassian.net/browse/BRID-58)

## High level description

The cert-manager namespace should be created along with the IAM policy/role, to prevent anything downstream from falling over.

[BRID-58]: https://digicatapult.atlassian.net/browse/BRID-58?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ