### PR TITLE
Fix cert-manager IAM subject

### DIFF
--- a/modules/aws/cert-manager/main.tf
+++ b/modules/aws/cert-manager/main.tf
@@ -71,5 +71,5 @@ module "cert_manager_irsa" {
   role_name                     = "cert-manager-requests"
   provider_url                  = replace(var.eks_cluster_identity_oidc_issuer, "https://", "")
   role_policy_arns              = [aws_iam_policy.issuers.arn]
-  oidc_fully_qualified_subjects = ["system:serviceaccount:cert-manager:cert-manager"]
+  oidc_fully_qualified_subjects = ["system:serviceaccount:cert-manager:cert-manager-controller"]
 }


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [x] Bug Fix

## Linked tickets

[BRID-57](https://digicatapult.atlassian.net/browse/BRID-57)

## High level description

The IAM trust relationship is pointing at the wrong subject, and should be using the cert-manager-controller service account.

[BRID-57]: https://digicatapult.atlassian.net/browse/BRID-57?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ