### PR TITLE
Add support for creating multiple buckets

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,13 +104,19 @@ In terms of structure, the environments will mostly comprise Terragrunt (HCL) an
 ├── env
 │   └── test
 │       ├── aws
+│       │   ├── cert-manager
 │       │   ├── eks
+│       │   ├── external-dns
+│       │   ├── mlflow
 │       │   └── vpc
 │       ├── flux
 │       └── github
 └── modules
     ├── aws
+    │   ├── cert-manager
     │   ├── eks
+    │   ├── external-dns
+    │   ├── mlflow
     │   └── vpc
     ├── flux
     └── github
@@ -155,6 +161,10 @@ profile: "digicat-mlops"
 project: "mlops"
 region: "eu-west-2"
 stage: "pipeline"
+bucket_prefix: "bridgeai"
+mlflow_bucket_name: "model-artefacts"
+dvc_bucket_name: "dvc-remote"
+evidently_bucket_name: "evidently-reports"
 ```
 
 At least two availability zones are needed for the EKS' API call `CreateCluster`, hence the above example includes "eu-west-2a" and "eu-west-2b". Given the above, the CIDR block likely ought to be sufficiently large enough to be able to distinguish public and private subnets across the different zones.

--- a/env/test/aws/mlflow/terragrunt.hcl
+++ b/env/test/aws/mlflow/terragrunt.hcl
@@ -25,7 +25,10 @@ locals {
 inputs = merge(
   local.eks_vars.inputs,
   {
-    bucket_list                          = local.global.bucket_list
+    mlflow_bucket_name    = local.global.mlflow_bucket_name
+    dvc_bucket_name       = local.global.dvc_bucket_name
+    evidently_bucket_name = local.global.evidently_bucket_name
+
     eks_cluster_id                       = dependency.eks.outputs.eks_cluster_id
     eks_cluster_identity_oidc_issuer     = dependency.eks.outputs.eks_cluster_identity_oidc_issuer
     eks_cluster_identity_oidc_issuer_arn = dependency.eks.outputs.eks_cluster_identity_oidc_issuer_arn

--- a/env/test/env.yaml
+++ b/env/test/env.yaml
@@ -12,7 +12,9 @@ project: "mlops"
 region: "eu-west-2"
 stage: "pipeline"
 bucket_prefix: "bridgeai"
-bucket_list: ["mlflow-artifacts", "kserve-models", "evidently-reports"]
+mlflow_bucket_name: "model-artefacts"
+dvc_bucket_name: "dvc-remote"
+evidently_bucket_name: "evidently-reports"
 
 # Clusters
 ami_type: "AL2_x86_64"

--- a/modules/aws/mlflow/outputs.tf
+++ b/modules/aws/mlflow/outputs.tf
@@ -1,7 +1,7 @@
 output "bucket_id" {
-  value       = [module.s3_bucket.*.bucket_id]
+  value       = [for s in module.s3_bucket : s.bucket_id]
 }
 
 output "bucket_arn" {
-  value       = [module.s3_bucket.*.bucket_arn]
+  value       = [for s in module.s3_bucket : s.bucket_arn]
 }

--- a/modules/aws/mlflow/variables.tf
+++ b/modules/aws/mlflow/variables.tf
@@ -7,19 +7,16 @@ variable "bucket_prefix" {
   default     = "bridgeai"
 }
 
-variable "bucket_list" {
-  type        = list
-  default     = ["mlflow", "kserve", "evidently"]
+variable "mlflow_bucket_name" {
+  type        = string
 }
 
-variable "namespace_list" {
-  type        = list
-  default     = ["mlflow", "kserve", "evidently"]
+variable "dvc_bucket_name" {
+  type        = string
 }
 
-variable "service_account_list" {
-  type        = list
-  default     = ["mlflow", "kserve", "evidently"]
+variable "evidently_bucket_name" {
+  type        = string
 }
 
 variable "eks_cluster_id" {
@@ -40,6 +37,12 @@ variable "kubeconfig_path" {
 }
 
 locals {
+  bucket_list = [
+    var.mlflow_bucket_name,
+    var.dvc_bucket_name,
+    var.evidently_bucket_name
+  ]
+
   account_id = data.aws_caller_identity.current.account_id
 
   kubeconfig_context = "arn:aws:eks:${var.region}:${local.account_id}:cluster/${var.eks_cluster_id}"


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [x] Feature

## Linked tickets

[BRID-70](https://digicatapult.atlassian.net/browse/BRID-70)
[BRID-55](https://digicatapult.atlassian.net/browse/BRID-55)

## High level description

This PR stands up buckets, roles, and policies for each of the MLOps components that will have to store artefacts in S3. Bucket names are global, hence that is something the user will need to control themselves and the environment variable `bucket_list` should facilitate that.

[BRID-70]: https://digicatapult.atlassian.net/browse/BRID-70?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BRID-55]: https://digicatapult.atlassian.net/browse/BRID-55?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ