### PR TITLE
Add t3.large node group

### DIFF
--- a/modules/aws/eks/main.tf
+++ b/modules/aws/eks/main.tf
@@ -62,3 +62,30 @@ module "eks_node_group" {
 
   context = module.this.context
 }
+
+module "eks_node_group_large" {
+  source                            = "cloudposse/eks-node-group/aws"
+  version                           = "3.0.1"
+
+  namespace                         = "${local.namespace}-1"
+  desired_size                      = 3
+  min_size                          = 1
+  max_size                          = 5
+  ami_type                          = var.ami_type
+  instance_types                    = ["t3.large"]
+  capacity_type                     = var.capacity_type
+  kubernetes_labels                 = var.kubernetes_labels
+  kubernetes_version                = [var.kubernetes_version]
+  subnet_ids                        = var.private_az_subnet_ids
+  cluster_name                      = module.eks_cluster.eks_cluster_id
+  create_before_destroy             = true
+
+  context = module.this.context
+
+  tags = {
+    "Attributes"  = "workers"
+    "Environment" = "test"
+    "Name"        = "mlops-test-workers"
+    "Namespace"   = "mlops"
+  }
+}


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [x] Chore

## High level description

This PR adds t3.large nodes to the BridgeAI production cluster to eliminate OOM issues elsewhere.