### PR TITLE
Correct namespace to airflow

### DIFF
--- a/modules/aws/ecr/main.tf
+++ b/modules/aws/ecr/main.tf
@@ -49,7 +49,7 @@ module "aws_iam_read_only_access" {
   role_name                     = "ecr-credentials-sync-role"
   provider_url                  = local.oidc_provider
   role_policy_arns              = ["arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"]
-  oidc_fully_qualified_subjects = ["system:serviceaccount:flux-system:ecr-credentials-sync"]
+  oidc_fully_qualified_subjects = ["system:serviceaccount:airflow:ecr-credentials-sync"]
 }
 
 # Provide pull permissions for inference services


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [x] Bug Fix

## High level description

The existing ecr-sync cronjob can't access any secrets outside its own namespace (flux-system), hence the current solution isn't working with our service accounts. Changing the SA namespace and moving the cronjob to the airflow namespace is a suitable fix.