### PR TITLE
Increase block size and type for redundancy

### DIFF
--- a/modules/aws/eks/main.tf
+++ b/modules/aws/eks/main.tf
@@ -60,6 +60,14 @@ module "eks_node_group" {
   cluster_name                      = module.eks_cluster.eks_cluster_id
   create_before_destroy             = true
 
+  block_device_mappings = [{
+    device_name           = "/dev/xvda"
+    volume_size           = 100
+    volume_type           = "gp3"
+    encrypted             = true
+    delete_on_termination = true
+  }]
+
   context = module.this.context
 }
 
@@ -79,6 +87,49 @@ module "eks_node_group_large" {
   subnet_ids                        = var.private_az_subnet_ids
   cluster_name                      = module.eks_cluster.eks_cluster_id
   create_before_destroy             = true
+
+  block_device_mappings = [{
+    device_name           = "/dev/xvda"
+    volume_size           = 100
+    volume_type           = "gp3"
+    encrypted             = true
+    delete_on_termination = true
+  }]
+
+  context = module.this.context
+
+  tags = {
+    "Attributes"  = "workers"
+    "Environment" = "test"
+    "Name"        = "mlops-test-workers"
+    "Namespace"   = "mlops"
+  }
+}
+
+module "eks_node_group_2xlarge" {
+  source                            = "cloudposse/eks-node-group/aws"
+  version                           = "3.0.1"
+
+  namespace                         = "${local.namespace}-2"
+  desired_size                      = 1
+  min_size                          = 1
+  max_size                          = 1
+  ami_type                          = var.ami_type
+  instance_types                    = ["t3.2xlarge"]
+  capacity_type                     = var.capacity_type
+  kubernetes_labels                 = var.kubernetes_labels
+  kubernetes_version                = [var.kubernetes_version]
+  subnet_ids                        = var.private_az_subnet_ids
+  cluster_name                      = module.eks_cluster.eks_cluster_id
+  create_before_destroy             = true
+
+  block_device_mappings = [{
+    device_name           = "/dev/xvda"
+    volume_size           = 100
+    volume_type           = "gp3"
+    encrypted             = true
+    delete_on_termination = true
+  }]
 
   context = module.this.context
 


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [x] Bug Fix

## High level description

Building Docker images via DAG consumes more RAM and disk space than anticipated, hence this is more of a temporary fix to ensure that an end-to-end demonstration of the pipeline is possible.

## Operational impact

This does increase the costs involved, hence the larger instance types should be scaled down as soon as it's practical.