### PR TITLE
Remove outdated text regarding CSI add-ons

### DIFF
--- a/env/test/github/terragrunt.hcl
+++ b/env/test/github/terragrunt.hcl
@@ -1,6 +1,0 @@
-# TODO: Bootstrap GitHub credentials
-terraform {
-  source = "../../modules/github"
-}
-
-inputs = {}


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [x] Documentation Update

## Linked tickets

[BRID-81](https://digicatapult.atlassian.net/browse/BRID-81)

## High level description

An earlier PR removed broken CSI add-ons without updating the documentation. This PR resolves the discrepancy.

It also removes references to GitHub modules that won't be featured.

[BRID-81]: https://digicatapult.atlassian.net/browse/BRID-81?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ